### PR TITLE
Build out of the box with sbt-extras

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,1 +1,3 @@
 seq(giter8Settings :_*)
+
+scalaVersion := "2.9.1"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.11.2

--- a/src/main/g8/build.sbt
+++ b/src/main/g8/build.sbt
@@ -9,7 +9,7 @@ libraryDependencies ++= Seq(
   "net.databinder" %% "unfiltered-jetty" % "$unfiltered_version$",
   // note: scalate 1.5.3 leaves sbt's run task hanging
   "org.fusesource.scalate" % "scalate-core" % "1.5.2",
-  "org.clapper" %% "avsl" % "0.3.6"
+  "org.clapper" %% "avsl" % "0.4"
 )
 
 resolvers ++= Seq(


### PR DESCRIPTION
When using sbt-extras, I hit this issue:

```
[info] Resolving org.clapper#avsl_2.9.2;0.3.6 ...
[warn]  module not found: org.clapper#avsl_2.9.2;0.3.6
[warn] ==== local: tried
[warn]   /home/noahlz/.ivy2/local/org.clapper/avsl_2.9.2/0.3.6/ivys/ivy.xml
[warn] ==== java m2: tried
[warn]   http://download.java.net/maven/2/org/clapper/avsl_2.9.2/0.3.6/avsl_2.9.2-0.3.6.pom
[warn] ==== public: tried
[warn]   http://repo1.maven.org/maven2/org/clapper/avsl_2.9.2/0.3.6/avsl_2.9.2-0.3.6.pom
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  ::          UNRESOLVED DEPENDENCIES         ::
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
[warn]  :: org.clapper#avsl_2.9.2;0.3.6: not found
[warn]  ::::::::::::::::::::::::::::::::::::::::::::::
```

This change allows you to build this g8 template out of the box.
